### PR TITLE
gemspec: Allow Bundler 2, drop unused directive

### DIFF
--- a/shortuuid.gemspec
+++ b/shortuuid.gemspec
@@ -15,10 +15,9 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler', '>= 1.11'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'minitest', '~> 5.0'
 end


### PR DESCRIPTION
This gem exposes no excutables.